### PR TITLE
fix: handle external on server build

### DIFF
--- a/packages/vite/misc/rolldown-runtime.js
+++ b/packages/vite/misc/rolldown-runtime.js
@@ -109,6 +109,10 @@ var rolldown_runtime = (self.rolldown_runtime = {
     }
     var factory = this.moduleFactoryMap[id]
     if (!factory) {
+      // handle external
+      if (typeof __require_external !== 'undefined') {
+        return __require_external(id)
+      }
       throw new Error('Module not found: ' + id)
     }
     var module = (this.moduleCache[id] = {

--- a/packages/vite/src/node/server/environments/rolldown.ts
+++ b/packages/vite/src/node/server/environments/rolldown.ts
@@ -412,9 +412,7 @@ class RolldownModuleRunner {
     __rolldown_hot: {
       send: () => {},
     },
-    // TODO: external require doesn't work in app format.
-    // TODO: also it should be aware of importer for non static require/import.
-    _require: require,
+    __require_external: require,
   }
 
   // TODO: support resolution?
@@ -458,25 +456,6 @@ ${sourcemap}
 function patchRuntimePlugin(environment: RolldownEnvironment): rolldown.Plugin {
   return {
     name: 'vite:rolldown-patch-runtime',
-    // TODO: external require doesn't work in app format.
-    // rewrite `require -> _require` and provide _require from module runner.
-    // for now just rewrite known ones in "react-dom/server".
-    transform: {
-      filter: {
-        code: {
-          include: [/require\(['"](stream|util)['"]\)/],
-        },
-      },
-      handler(code) {
-        if (!environment.rolldownDevOptions.ssrModuleRunner) {
-          return
-        }
-        return code.replace(
-          /require(\(['"](stream|util)['"]\))/g,
-          '_require($1)',
-        )
-      },
-    },
     renderChunk(code, chunk) {
       if (!chunk.isEntry) {
         return


### PR DESCRIPTION
- base https://github.com/hi-ogawa/vite/pull/8

_todo_

- [x] node builtin
- [ ] literal importee `require("lib")` should get resolved like Vite's external condition
- [ ] what to do with non-literal ones? `require(someLib)`