### PR TITLE
refactor: load client build as esm

### DIFF
--- a/packages/vite/misc/rolldown-runtime.js
+++ b/packages/vite/misc/rolldown-runtime.js
@@ -82,6 +82,12 @@ var __toBinary = /* @__PURE__ */ (() => {
   }
 })()
 
+// TODO: for now need to expose these utilities used by IsolatingModuleFinalizermodule
+self.__toCommonJS = __toCommonJS
+self.__toESM = __toESM
+self.__export = __export
+self.__reExport = __reExport
+
 var rolldown_runtime = (self.rolldown_runtime = {
   patching: false,
   patchedModuleFactoryMap: {},

--- a/packages/vite/src/node/plugins/html.ts
+++ b/packages/vite/src/node/plugins/html.ts
@@ -775,13 +775,7 @@ export function buildHtmlPlugin(config: ResolvedConfig): RolldownPlugin {
         tag: 'script',
         attrs: {
           ...(isAsync ? { async: true } : {}),
-          ...(config.experimental.rolldownDev
-            ? {
-                defer: true,
-              }
-            : {
-                type: 'module',
-              }),
+          type: 'module',
           // crossorigin must be set not only for serving assets in a different origin
           // but also to make it possible to preload the script using `<link rel="preload">`.
           // `<script type="module">` used to fetch the script with credential mode `omit`,

--- a/packages/vite/src/node/server/environments/rolldown.ts
+++ b/packages/vite/src/node/server/environments/rolldown.ts
@@ -596,12 +596,12 @@ function getReactRefreshRuntimeCode() {
     (() => {
       __react_refresh_runtime.injectIntoGlobalHook(self);
 
-      __react_refresh_transform_define = (file) => [
+      self.__react_refresh_transform_define = (file) => [
         __react_refresh_runtime.createSignatureFunctionForTransform,
         (type, id) => __react_refresh_runtime.register(type, file + '_' + id)
       ];
 
-      __react_refresh_transform_setupHot = (hot) => {
+      self.__react_refresh_transform_setupHot = (hot) => {
         hot.accept((prev) => {
           debouncedRefresh();
         });

--- a/packages/vite/src/node/server/environments/rolldown.ts
+++ b/packages/vite/src/node/server/environments/rolldown.ts
@@ -434,10 +434,6 @@ class RolldownModuleRunner {
     }
     code = `\
 'use strict';(${Object.keys(context).join(',')})=>{{${code}
-// TODO: need to re-expose runtime utilities for now
-self.__toCommonJS = __toCommonJS;
-self.__export = __export;
-self.__toESM = __toESM;
 }}
 //# sourceURL=${sourceURL}
 //# sourceMappingSource=rolldown-module-runner

--- a/playground/rolldown-dev-ssr/src/entry-server.tsx
+++ b/playground/rolldown-dev-ssr/src/entry-server.tsx
@@ -20,7 +20,7 @@ const handler: Connect.SimpleHandleFunction = (req, res) => {
 	</head>
 	<body>
 		<div id="root">${ssrHtml}</div>
-		<script src="/entry-client.js"></script>
+		<script type="module" src="/entry-client.js"></script>
 	</body>
 </html>
 `)


### PR DESCRIPTION
### Description

- base https://github.com/hi-ogawa/vite/pull/9

Not much expect reducing the diff from original vite, but switching to esm can spot bad global variables hack, so let's fix that.
